### PR TITLE
surface next_ts and make is_first a query parameter

### DIFF
--- a/tests/test_next_query
+++ b/tests/test_next_query
@@ -1,0 +1,39 @@
+"""
+tests for the webhose interface.
+
+note that the webhose token is taken from the WEBHOSE_TOKEN environment variable
+"""
+
+import unittest
+import os
+
+import webhose
+
+class NextTestCase(unittest.TestCase):
+    def test_next(self):
+        """
+        check that if we use the 'since' parameter from one query, that we
+        don't get any overlap
+        """
+
+        # run a "regular" query
+        webhose.config(os.environ['WEBHOSE_TOKEN'])
+        query = webhose.Query()
+        query.some_terms = ('boston','red sox')
+        query.language = 'english'
+        query.site_type = 'news'
+
+        response = webhose.search(query)
+
+        # grab some stuff that we need for testing
+        next_ts = response.next_ts
+        last_post_crawled = response.posts[99].crawled_parsed
+
+        # now run our second query
+        response = webhose.search(query)
+
+        self.assertGreater(response.posts[99].crawled_parsed,
+                           last_post_crawled)
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_next_query.py
+++ b/tests/test_next_query.py
@@ -1,0 +1,39 @@
+"""
+tests for the webhose interface.
+
+note that the webhose token is taken from the WEBHOSE_TOKEN environment variable
+"""
+
+import unittest
+import os
+
+import webhose
+
+class NextTestCase(unittest.TestCase):
+    def test_next(self):
+        """
+        check that if we use the 'since' parameter from one query, that we
+        don't get any overlap
+        """
+
+        # run a "regular" query
+        webhose.config(os.environ['WEBHOSE_TOKEN'])
+        query = webhose.Query()
+        query.some_terms = ('boston','red sox')
+        query.language = 'english'
+        query.site_type = 'news'
+
+        response = webhose.search(query)
+
+        # grab some stuff that we need for testing
+        next_ts = response.next_ts
+        last_post_crawled = response.posts[99].crawled_parsed
+
+        # now run our second query
+        response = webhose.search(query, since=response.next_ts)
+
+        self.assertGreater(response.posts[99].crawled_parsed,
+                           last_post_crawled)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/webhose/__init__.py
+++ b/webhose/__init__.py
@@ -22,6 +22,7 @@ class Query(object):
         self.site = None
         self.title = None
         self.body_text = None
+        self.is_first = None
 
     def query_string(self):
         qs = []
@@ -52,6 +53,8 @@ class Query(object):
             qs.append("title:%s" % self.title)
         if self.body_text:
             qs.append("text:%s" % self.body_text)
+        if self.is_first:
+            qs.append("is_first:true")
         return " AND ".join("(%s)" % term for term in qs)
 
     def __str__(self):


### PR DESCRIPTION
two changes in here:

* the first is to make the next_ts attribute visible on the response.  I needed that because I store the next_ts value so that I can use it the next time my webhose-querying script runs. 

My alternative solution, which I like better, would be to provide a callback function that the response iterator would call.  That could be really useful for doing things like persisting next_ts, keeping track of the number of webhose API calls, etc.  But that is more complicated.

* the second is to just make the is_first query parameter accessible via the Query object.